### PR TITLE
add last_activity to session

### DIFF
--- a/openstack_auth/views.py
+++ b/openstack_auth/views.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import logging
+import time
 
 import django
 from django.conf import settings
@@ -102,6 +103,7 @@ def login(request, template_name=None, extra_context=None, **kwargs):
         region_name = regions.get(region)
         request.session['region_endpoint'] = region
         request.session['region_name'] = region_name
+        request.session['last_activity'] = int(time.time())
     return res
 
 


### PR DESCRIPTION
Actually, the fix for CVE-2014-8124 included a regression, resulting
users had to log in a second time, after being logged out due to
inactivity.

Change-Id: If6a7f489058c80c969975dc0658e6f2ae979eca3
Closes-Bug: 1403037
(cherry picked from commit 336d7a531d8fb422e3b86a46b865339b3a321902)
